### PR TITLE
feat: cross-bot dedup v2 — scope split + review delay

### DIFF
--- a/src/clients/github.py
+++ b/src/clients/github.py
@@ -169,6 +169,9 @@ class GitHubClient:
                 log.warning("Failed to fetch %s: %d", path, response.status_code)
                 break
             items = response.json()
+            if not isinstance(items, list):
+                log.warning("Unexpected response type from %s: %s", path, type(items))
+                break
             all_items.extend(items)
             if len(items) < per_page:
                 break

--- a/src/clients/github.py
+++ b/src/clients/github.py
@@ -152,6 +152,51 @@ class GitHubClient:
         if response.status_code not in (200, 201):
             log.error("Failed to post comment: %d %s", response.status_code, response.text)
 
+    async def get_pr_comments(
+        self, installation_id: int, owner: str, repo: str, pr_number: int,
+    ) -> list[dict]:
+        """Fetch inline review comments on a PR."""
+        token = await self._get_installation_token(installation_id)
+        response = await self._client.get(
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/comments",
+            headers=self._auth_headers(token),
+            params={"per_page": 100},
+        )
+        if response.status_code != 200:
+            log.warning("Failed to fetch PR comments: %d", response.status_code)
+            return []
+        return response.json()
+
+    async def get_pr_reviews(
+        self, installation_id: int, owner: str, repo: str, pr_number: int,
+    ) -> list[dict]:
+        """Fetch top-level reviews on a PR."""
+        token = await self._get_installation_token(installation_id)
+        response = await self._client.get(
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews",
+            headers=self._auth_headers(token),
+            params={"per_page": 100},
+        )
+        if response.status_code != 200:
+            log.warning("Failed to fetch PR reviews: %d", response.status_code)
+            return []
+        return response.json()
+
+    async def get_issue_comments(
+        self, installation_id: int, owner: str, repo: str, issue_number: int,
+    ) -> list[dict]:
+        """Fetch issue-level comments on a PR/issue."""
+        token = await self._get_installation_token(installation_id)
+        response = await self._client.get(
+            f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
+            headers=self._auth_headers(token),
+            params={"per_page": 100},
+        )
+        if response.status_code != 200:
+            log.warning("Failed to fetch issue comments: %d", response.status_code)
+            return []
+        return response.json()
+
     async def close(self) -> None:
         """Close the underlying HTTP client."""
         await self._client.aclose()

--- a/src/clients/github.py
+++ b/src/clients/github.py
@@ -152,50 +152,51 @@ class GitHubClient:
         if response.status_code not in (200, 201):
             log.error("Failed to post comment: %d %s", response.status_code, response.text)
 
+    async def _fetch_paginated(
+        self, installation_id: int, path: str, max_pages: int = 3,
+    ) -> list[dict]:
+        """Fetch a paginated list endpoint, returning up to max_pages of results."""
+        token = await self._get_installation_token(installation_id)
+        all_items: list[dict] = []
+        per_page = 100
+        for page in range(1, max_pages + 1):
+            response = await self._client.get(
+                path,
+                headers=self._auth_headers(token),
+                params={"per_page": per_page, "page": page},
+            )
+            if response.status_code != 200:
+                log.warning("Failed to fetch %s: %d", path, response.status_code)
+                break
+            items = response.json()
+            all_items.extend(items)
+            if len(items) < per_page:
+                break
+        return all_items
+
     async def get_pr_comments(
         self, installation_id: int, owner: str, repo: str, pr_number: int,
     ) -> list[dict]:
         """Fetch inline review comments on a PR."""
-        token = await self._get_installation_token(installation_id)
-        response = await self._client.get(
-            f"/repos/{owner}/{repo}/pulls/{pr_number}/comments",
-            headers=self._auth_headers(token),
-            params={"per_page": 100},
+        return await self._fetch_paginated(
+            installation_id, f"/repos/{owner}/{repo}/pulls/{pr_number}/comments",
         )
-        if response.status_code != 200:
-            log.warning("Failed to fetch PR comments: %d", response.status_code)
-            return []
-        return response.json()
 
     async def get_pr_reviews(
         self, installation_id: int, owner: str, repo: str, pr_number: int,
     ) -> list[dict]:
         """Fetch top-level reviews on a PR."""
-        token = await self._get_installation_token(installation_id)
-        response = await self._client.get(
-            f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews",
-            headers=self._auth_headers(token),
-            params={"per_page": 100},
+        return await self._fetch_paginated(
+            installation_id, f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews",
         )
-        if response.status_code != 200:
-            log.warning("Failed to fetch PR reviews: %d", response.status_code)
-            return []
-        return response.json()
 
     async def get_issue_comments(
         self, installation_id: int, owner: str, repo: str, issue_number: int,
     ) -> list[dict]:
         """Fetch issue-level comments on a PR/issue."""
-        token = await self._get_installation_token(installation_id)
-        response = await self._client.get(
-            f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
-            headers=self._auth_headers(token),
-            params={"per_page": 100},
+        return await self._fetch_paginated(
+            installation_id, f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
         )
-        if response.status_code != 200:
-            log.warning("Failed to fetch issue comments: %d", response.status_code)
-            return []
-        return response.json()
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""

--- a/src/config.py
+++ b/src/config.py
@@ -77,5 +77,6 @@ class JulianSettings(BaseSettings):
     log_level: str = "INFO"
     log_buffer_size: int = 200
     guidelines_dir: str = Field(default="guidelines")
+    review_delay_seconds: int = Field(default=30)
 
     model_config = {"env_prefix": "JULIAN_"}

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -109,7 +109,7 @@ class GeminiClient:
             log.error("Unexpected response format: %s", exc)
             return "The plan hit a snag, boys. Let me regroup."
 
-    async def generate_review(self, diff: str, guidelines: str) -> str:
+    async def generate_review(self, diff: str, guidelines: str, existing_feedback: str = "") -> str:
         """Generate a Julian-style pattern enforcement review."""
         system_prompt = f"""{JULIAN_PERSONA}
 
@@ -122,14 +122,24 @@ Review this PR diff for pattern violations and style inconsistencies.
 - Suggest how to align with the patterns
 - Praise code that follows patterns well
 - Stay in character as Julian throughout
+- If other reviewers (Ricky, Julian, or humans) already flagged an issue, don't repeat it
+- On follow-up reviews, focus on NEW code and NEW issues only
+- If all issues have been addressed, say so briefly
 
 Start with: "Alright boys, let me take a look at what we've got here..."
 """
 
+        existing_section = ""
+        if existing_feedback:
+            existing_section = f"""
+Existing comments on this PR (DO NOT repeat these points):
+{existing_feedback}
+
+"""
+
         truncated_diff = diff[: self._settings.max_diff_chars]
         user_prompt = f"""Review this diff and enforce our coding patterns:
-
-```diff
+{existing_section}```diff
 {truncated_diff}
 ```"""
 

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -117,11 +117,13 @@ class GeminiClient:
 {guidelines}
 
 ## Your Task
-Review this PR diff for pattern violations and style inconsistencies.
-- Point out deviations from the coding guidelines
-- Suggest how to align with the patterns
+Review this PR diff for pattern violations and style inconsistencies per the guidelines below.
+- Point out deviations from the coding guidelines: naming, structure, indentation, type annotations, import ordering, file organization, DRY violations, and architectural patterns
+- Suggest how to align with the established patterns
 - Praise code that follows patterns well
 - Stay in character as Julian throughout
+- DO NOT flag: security vulnerabilities, bugs, logic errors, resource leaks, or runtime correctness issues — Ricky handles those
+- If something is both a security issue AND a pattern violation, frame it ONLY as a pattern violation
 - If other reviewers (Ricky, Julian, or humans) already flagged an issue, don't repeat it
 - On follow-up reviews, focus on NEW code and NEW issues only
 - If all issues have been addressed, say so briefly


### PR DESCRIPTION
## Summary

- **Scope narrowing**: Julian's review prompt now focuses exclusively on pattern conformance (naming, structure, indentation, type annotations, import ordering, DRY violations, architectural patterns) and explicitly excludes security/bugs/runtime issues that Ricky handles
- **Removed `security.md` from always-include**: Runtime security checks (SQL injection, shell=True, hardcoded secrets) are Ricky's domain — pattern-level security already lives in language-specific guides
- **Configurable review delay**: Added `review_delay_seconds` (default 30s, via `JULIAN_REVIEW_DELAY_SECONDS`) so Julian waits for Ricky to post before fetching comments, fixing first-review race condition

## Changed files

| File | Change |
|------|--------|
| `src/config.py` | Added `review_delay_seconds: int = Field(default=30)` to `JulianSettings` |
| `src/gemini_client.py` | Expanded task description with explicit scope boundaries, excludes security/bugs |
| `src/webhook_handler.py` | Removed `security.md` from `_ALWAYS_INCLUDE`, added configurable delay before review |

## Test plan

- [ ] Syntax check passes on all modified files
- [ ] Deploy and open a test PR with mixed issues (deeply nested code + missing type annotations should be flagged, security issues should not)
- [ ] Verify Julian's review appears ~30s after Ricky's inline comments
- [ ] Set `JULIAN_REVIEW_DELAY_SECONDS=0` and verify delay is skipped
- [ ] Push follow-up commit and verify dedup still works

Part of the cross-bot dedup optimization (iteration 2). Companion PR in ricky repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)